### PR TITLE
Pass `error_on_status` to event loop

### DIFF
--- a/R/xprocess.R
+++ b/R/xprocess.R
@@ -67,7 +67,7 @@ external_process <- function(process_generator, error_on_status = TRUE,
         list(pipe),
         function(err, res) if (is.null(err)) resolve(res) else reject(err),
         list(process = px, stdout = stdout, stderr = stderr,
-             error_on_status = TRUE, encoding = args$encoding)
+             error_on_status = error_on_status, encoding = args$encoding)
       )
     },
     on_cancel = function(reason) {

--- a/tests/testthat/test-external-process.R
+++ b/tests/testthat/test-external-process.R
@@ -78,3 +78,28 @@ test_that("discarding stdout/stderr works", {
   expect_null(res$stderr)
   expect_false(res$timeout)
 })
+
+test_that("can disable error on status", {
+  px <- asNamespace("processx")$get_tool("px")
+  pxgen <- function(...) {
+    processx::process$new(
+      px,
+      c("return", "1"),
+      ...
+    )
+  }
+  afun <- function(...) external_process(pxgen, ...)
+
+  expect_error(
+    synchronise(afun()),
+    "exited with non-zero status"
+  )
+
+  res <- synchronise(afun(error_on_status = FALSE))
+  expect_equal(res, list(
+    status = 1L,
+    stdout = NULL,
+    stderr = NULL,
+    timeout = FALSE
+  ))
+})


### PR DESCRIPTION
Should we move this argument after `...` to force it to be named? This would also make it possible to pass a function directly followed by its arguments, which is probably more natural. I got confused at some point because passing args didn't seem to work because I didn't notice there's `error_on_status` in the way.